### PR TITLE
feat(autocopr): use GraphQL API over REST API

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -6,6 +6,10 @@ on:
     # Runs at 12:00am UTC -> 5:00pm PDT
     - cron: '0 0 * * *'
 
+permissions:
+  # Needs to write to this repo
+  contents: write
+
 jobs:
   update:
     name: update
@@ -19,6 +23,19 @@ jobs:
           python-version: '3.11' # Need python version for cache
           cache: 'pip' # caching pip dependencies
           
+      - name: Cache GraphQL API IDs
+        uses: actions/cache@v3
+        with:
+          path: specs/graphql_id_cache.json
+          # This key is overkill - we realy only need to update the
+          # cache when a *new* spec file is added, not when *any* spec
+          # file changes. However, this seems to be the easiest way
+          # to achieve that from within Actions.
+          key: graphql-ids-${{ hashFiles('specs/*.spec') }}
+          # Make sure even if the specs change it grabs the old cache
+          # to start from! Entries are never invalidated, only added
+          restore-keys: graphql-ids
+          
       - name: Install dependencies
         run: pip install -r requirements.txt
         
@@ -29,4 +46,5 @@ jobs:
           
       - name: Check and update spec files
         run: python -m autocopr.autocopr --verbose --in-place --push specs
-          
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+graphql_id_cache.json

--- a/README.md
+++ b/README.md
@@ -176,20 +176,22 @@ python -m autocopr.autocopr --verbose --in-place --push specs
 
 which means that it will print all info to standard out, will not create
 backups, will push all spec file changes, and only searches the `specs` folder
-for spec files.
+for spec files. It also passes a Github token in the environment to allow for
+authentication to the GraphQL library.
 
 ### Integrating with Github Actions and COPR Automatic Builds
 This repo has a Github Action at .github/workflows/update.yml that runs the
 script every 24 hours. This process is detailed much further in
 [DOCS.md](DOCS.md), but if you know what you're doing here's a quick summary:
 
-- Read through [`autocopr.py`](autocopr/autocopr.py) and the
+- Read through [`autocopr`](autocopr/autocopr.py) and the
   [Github Actions workflow](.github/workflows/update.yml) to make sure you
-  understand and trust what this is doing
+  understand and trust what this is doing. Please note that the Github token
+  handed to the script has permissions to read/write to any of your repos, so
+  please make sure you understand and trust how that is used! It's only used
+  to push to its own repo and to authenticate to the GraphQL API, but you
+  should verify that I'm telling the truth here :)
 - Fork this repository (button in the top right)
-- Go to Settings -> Actions -> General, scroll to the bottom and set Workflow
-  Permissions to "Read and write permissions". This allows the Github workflow
-  to make pushes to the repo.
 - Empty the `specs` folder and put your own specs in.
 - Create a COPR repository, set up the packages for autobuild, and add its
   webhook to this repo to create automatic builds (more details in
@@ -211,14 +213,16 @@ run it manually from the Actions -> Update spec files -> "Run Workflow" button.
 
 ## Contributing
 Please feel free to leave any issues if you have questions about creating your
-own AutoCOPR!
+own AutoCOPR! I'm open to PRs to the autocopr program to make it better or add
+new features.
 
 I'm willing to accept PRs for existing specs if they have issues, but I'm not
 interested in adding more packages or adding more architectures than what I'm
 already doing. I only want to be pushing packages for programs I'm currently
 using - if there are issues with packages or architectures I'm not using, I'd
 be unaware of those issues, and since this repo is automated the issues could
-go undiscovered for a long time. Please feel free to make your own repo though!
+go undiscovered for a long time. Please feel free to fork and make your own
+COPR repo though!
 
 ## License
 MIT

--- a/README.md
+++ b/README.md
@@ -151,6 +151,11 @@ to only search the `specs` folder.
 
 There are a few flags:
 - `--help` will print all the flags and stop.
+- `--github-token` allows you to pass in a github token to use the GraphQL API,
+  which makes less requests to the Github API and therefore can be faster. It
+  can also be set with the `GITHUB_TOKEN` environment variable to keep the
+  token out of your terminal history. The command line flag will take priority
+  over the environment variable.
 - `-d / --dry-run` will not edit any files, and only print if files are
   outdated.
 - `-v / --verbose` will print all information to stdout.

--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ There are a few flags:
   which makes less requests to the Github API and therefore can be faster. It
   can also be set with the `GITHUB_TOKEN` environment variable to keep the
   token out of your terminal history. The command line flag will take priority
-  over the environment variable.
+  over the environment variable. Using the GraphQL api will create a
+  `graphql_id_cache.json` file with your specs that stores GraphQL ids for each
+  repo.
 - `-d / --dry-run` will not edit any files, and only print if files are
   outdated.
 - `-v / --verbose` will print all information to stdout.

--- a/README.md
+++ b/README.md
@@ -152,12 +152,16 @@ to only search the `specs` folder.
 There are a few flags:
 - `--help` will print all the flags and stop.
 - `--github-token` allows you to pass in a github token to use the GraphQL API,
-  which makes less requests to the Github API and therefore can be faster. It
-  can also be set with the `GITHUB_TOKEN` environment variable to keep the
-  token out of your terminal history. The command line flag will take priority
-  over the environment variable. Using the GraphQL api will create a
-  `graphql_id_cache.json` file with your specs that stores GraphQL ids for each
-  repo.
+  which makes less requests to the Github API and therefore is often faster.
+  It can also be set with the `GITHUB_TOKEN` environment variable (you may want
+  to do this to keep the token out of your terminal command history). Any token
+  defined with the command line flag will take priority over the environment
+  variable. The Github Action in this repo automatically provides a token, to
+  use it locally read [the GraphQL authentication
+  docs](https://docs.github.com/en/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql).
+  Using the GraphQL api will create a `graphql_id_cache.json` file with your
+  specs that stores GraphQL ids for each repo, this should be left alone for
+  quicker GraphQL queries.
 - `-d / --dry-run` will not edit any files, and only print if files are
   outdated.
 - `-v / --verbose` will print all information to stdout.

--- a/autocopr/autocopr.py
+++ b/autocopr/autocopr.py
@@ -24,7 +24,8 @@ def main():
         if (parsed := specdata.parse_spec(spec)) is not None
     ]
 
-    latest_vers = latestver.get_latest_versions(specs, args.github_token)
+    latest_vers = latestver.get_latest_versions(
+        specs, args.github_token, root_dir / "graphql_id_cache.json")
 
     update_summary = [f"{'Name':15}\t{'Old Version':8}\tNew Version"]
 

--- a/autocopr/autocopr.py
+++ b/autocopr/autocopr.py
@@ -24,7 +24,7 @@ def main():
         if (parsed := specdata.parse_spec(spec)) is not None
     ]
 
-    latest_vers = latestver.get_latest_versions(specs)
+    latest_vers = latestver.get_latest_versions(specs, args.github_token)
 
     update_summary = [f"{'Name':15}\t{'Old Version':8}\tNew Version"]
 

--- a/autocopr/cli.py
+++ b/autocopr/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import os
 
 
 def create_parser() -> argparse.ArgumentParser:
@@ -31,6 +32,11 @@ def create_parser() -> argparse.ArgumentParser:
         help="when updating a spec file, do not store a backup",
         action="store_true",
     )
+    parser.add_argument(
+        "--github-token",
+        default=os.environ.get("GITHUB_TOKEN"),
+        help=("Github token to use to access the GraphQL API. "
+              "Defaults to GITHUB_TOKEN environment variable if not set."))
     parser.add_argument(
         "directory",
         nargs="?",

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -93,6 +93,7 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
             logging.warning(f"Error accessing id for {spec.name}, skipping")
             logging.warning("API response:")
             logging.warning(resp)
+            continue
 
         logging.info(f"Adding {id=} for {spec.name} to cache")
         ids[spec.ownerName()] = id

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -140,14 +140,14 @@ def get_latest_versions(
     spec_releases = []
     for (spec, node) in zip((spec for (spec, _) in spec_ids),
                             resp['data']['nodes']):
-        if node:
-            latest = node['latestRelease']
+        if node and (latest := node['latestRelease']) and 'tagName' in latest:
             latest_version = clean_tag(latest['tagName'])
             logging.info(f"{spec.name} latest version is {latest_version}")
             spec_releases.append((spec, Latest(latest_version, latest['url'])))
         else:
             logging.warning(
                 f"Error getting latest release from {spec.name}. Skipping")
+            logging.info(f"Node response: {node}")
 
     if "errors" in resp:
         logging.warning("GraphQL errors when checking latest versions:")

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -1,10 +1,131 @@
+import json
 import logging
+from pathlib import Path
+
+import requests
 
 from ..specdata import SpecData
 from .latest import Latest
 
+# The GraphQL API allows us to specify exactly what we want, instead of
+# overfetching data we don't need from the REST API. This means that
+# we can have one connection to query all our repos at once, instead of
+# one connection per repo, and save network traffic from data we don't
+# need.
+#
+# However, it also introduces new requirements to deal with:
+# - We have to provide a Github token to use it. Doesn't cost money, but
+#   definitely more setup than REST.
+# - Idiomatic GraphQL does not use string interpolation to make queries
+#   ("we should never be doing string interpolation to construct queries from
+#   user-supplied values." - https://graphql.org/learn/queries/#variables)
+#   However, the Github GraphQL API doesn't allow us to submit a list of
+#   repositories, it only allows us to submit a list of node IDs. This means
+#   we need to maintain a repository -> node mapping locally, but once we have
+#   this cache we can refer to it for all future queries. So it's O(n)
+#   connections to get the repository IDs, but O(1) connections after we have
+#   this mapping.
+#
+# So overall approach:
+# - Get our spec -> ID mapping
+# - If we have new specs without an ID, get their IDs and update the cache
+# - Once we have all IDs, query repository information for them
+# - Map the GraphQL response to a Latest object (or disregard nulls) and return it
 
-def latest_versions(specs: list[SpecData],
-                    token: str) -> list[tuple[SpecData, Latest]]:
-    logging.error("GraphQL API in progress")
-    exit()
+graphQL_url = "https://api.github.com/graphql"
+ID = str
+
+
+def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
+                                                                      str],
+                 session: requests.Session) -> list[tuple[SpecData, ID]]:
+    """Given a list of specs, request headers, id cache, and session,
+    load the cache of id keys and fetch any new ones from GraphQl"""
+
+    if id_cache.exists():
+        with open(id_cache) as cache:
+            ids = json.load(cache)
+
+        logging.info(f"Loaded IDs for {ids.keys()} from {id_cache}")
+    else:
+        ids = {}
+        logging.info(f"No cache at {id_cache}, making a new one")
+
+    specs_that_need_key = [
+        spec for spec in specs if spec.ownerName() not in ids
+    ]
+
+    # GraphQL query that takes an owner and name, returns its id
+    get_id_query = """
+    query GetID($owner: String!, $name: String!) {
+      repository(owner: $owner, name: $name) {
+        id
+      }
+    }    
+    """
+
+    for spec in specs_that_need_key:
+        owner, name = spec.ownerName().split("/")
+        logging.info(f"Getting key for {spec.name} ({owner=}, {name=})")
+
+        resp = session.post(graphQL_url,
+                            json={
+                                "query": get_id_query,
+                                "variables": {
+                                    "owner": owner,
+                                    "name": name
+                                }
+                            },
+                            headers=headers).json()
+
+        if "errors" in resp:
+            logging.warning(
+                f"API error when getting {spec.name}'s GraphQL id':")
+            for error in resp['errors']:
+                logging.warning(error['message'])
+            logging.warning(f"Skipping {spec.name}...")
+
+            continue
+
+        try:
+            id = resp['data']['repository']['id']
+        except KeyError:
+            logging.warning(f"Error accessing id for {spec.name}, skipping")
+            logging.warning("API response:")
+            logging.warning(resp)
+
+        logging.info(f"Adding {id=} for {spec.name} to cache")
+        ids[spec.ownerName()] = id
+
+    if len(specs_that_need_key) > 0:
+        # We changed the cache, update it
+        logging.info(
+            "Writing new GraphQL cache since "
+            f"{[spec.name for spec in specs_that_need_key]} added")
+        with open(id_cache, "w") as out:
+            json.dump(ids, out, indent=2)
+    else:
+        logging.info("No new GraphQL keys added")
+
+    # Finally, map ids to their actual specs and return!
+    return [(spec, ids[spec.ownerName()]) for spec in specs]
+
+
+def latest_versions(specs: list[SpecData], token: str,
+                    id_cache: Path) -> list[tuple[SpecData, Latest]]:
+    """Given a list of specs, a github token, and a location to load and store
+    a cache of GraphQL ids, get the latest versions for all the specs given."""
+
+    with requests.session() as session:
+        headers = {
+            "Authorization": f"bearer {token}",
+            # https://docs.github.com/en/graphql/guides/migrating-graphql-global-node-ids
+            # Even though it's 2023, still need to hand in this header to get
+            # the latest IDs :shrug:
+            "X-Github-Next-Global-ID": "1"
+        }
+
+        ids = update_cache(id_cache, specs, headers, session)
+
+        logging.error("GraphQL API in progress")
+        exit()

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -99,9 +99,8 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
 
     if len(specs_that_need_key) > 0:
         # We changed the cache, update it
-        logging.info(
-            "Writing new GraphQL cache since "
-            f"{[spec.name for spec in specs_that_need_key]} added")
+        logging.info("Writing new GraphQL cache since "
+                     f"{[spec.name for spec in specs_that_need_key]} added")
         with open(id_cache, "w") as out:
             json.dump(ids, out, indent=2)
     else:
@@ -112,7 +111,7 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
 
 
 def get_latest_versions(
-        ids: list[tuple[SpecData, ID]], headers: dict[str, str],
+        spec_ids: list[tuple[SpecData, ID]], headers: dict[str, str],
         session: requests.Session) -> list[tuple[SpecData, Latest]]:
     # Query an id, if it's a repository (in our case it is) get the latest
     # release name and url
@@ -133,13 +132,13 @@ def get_latest_versions(
                         json={
                             "query": latest_versions,
                             "variables": {
-                                "ids": [id for (_, id) in ids]
+                                "ids": [id for (_, id) in spec_ids]
                             }
                         },
                         headers=headers).json()
 
     spec_releases = []
-    for (spec, node) in zip((spec for (spec, _) in ids),
+    for (spec, node) in zip((spec for (spec, _) in spec_ids),
                             resp['data']['nodes']):
         if node:
             latest = node['latestRelease']

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -115,6 +115,12 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
 def get_latest_versions(
         spec_ids: list[tuple[SpecData, ID]], headers: dict[str, str],
         session: requests.Session) -> list[tuple[SpecData, Latest]]:
+
+    # Special case this because the response won't have any data and will
+    # throw a key error. On all other instances we will have data.
+    if len(spec_ids) == 0:
+        return []
+
     # Query an id, if it's a repository (in our case it is) get the latest
     # release name and url
     latest_versions = """

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -179,6 +179,6 @@ def latest_versions(specs: list[SpecData], token: str,
             "X-Github-Next-Global-ID": "1"
         }
 
-        ids = update_cache(id_cache, specs, headers, session)
+        spec_ids = update_cache(id_cache, specs, headers, session)
 
-        return get_latest_versions(ids, headers, session)
+        return get_latest_versions(spec_ids, headers, session)

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -64,6 +64,7 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
     }    
     """
 
+    specs_that_got_added = []
     for spec in specs_that_need_key:
         owner, name = spec.ownerName().split("/")
         logging.info(f"Getting key for {spec.name} ({owner=}, {name=})")
@@ -96,12 +97,13 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
             continue
 
         logging.info(f"Adding {id=} for {spec.name} to cache")
+        specs_that_got_added.append(spec.name)
         ids[spec.ownerName()] = id
 
-    if len(ids) > 0:
+    if len(specs_that_got_added) > 0:
         # We changed the cache, update it
-        logging.info("Writing new GraphQL cache since "
-                     f"{[spec.name for spec in specs_that_need_key]} added")
+        logging.info(
+            f"Writing new GraphQL cache since {specs_that_got_added} added")
         with open(id_cache, "w") as out:
             json.dump(ids, out, indent=2)
     else:

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -98,7 +98,7 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
         logging.info(f"Adding {id=} for {spec.name} to cache")
         ids[spec.ownerName()] = id
 
-    if len(specs_that_need_key) > 0:
+    if len(ids) > 0:
         # We changed the cache, update it
         logging.info("Writing new GraphQL cache since "
                      f"{[spec.name for spec in specs_that_need_key]} added")
@@ -108,7 +108,8 @@ def update_cache(id_cache: Path, specs: list[SpecData], headers: dict[str,
         logging.info("No new GraphQL keys added")
 
     # Finally, map ids to their actual specs and return!
-    return [(spec, ids[spec.ownerName()]) for spec in specs]
+    return [(spec, ids[ownername]) for spec in specs
+            if (ownername := spec.ownerName()) in ids]
 
 
 def get_latest_versions(

--- a/autocopr/githubapi/graphql.py
+++ b/autocopr/githubapi/graphql.py
@@ -1,0 +1,10 @@
+import logging
+
+from ..specdata import SpecData
+from .latest import Latest
+
+
+def latest_versions(specs: list[SpecData],
+                    token: str) -> list[tuple[SpecData, Latest]]:
+    logging.error("GraphQL API in progress")
+    exit()

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -1,14 +1,28 @@
+import logging
+from typing import Optional
+
 import requests
 
-from .githubapi import rest
+from .githubapi import graphql, rest
 from .githubapi.latest import Latest
 from .specdata import SpecData
 
 
-def get_latest_versions(
-        specs: list[SpecData]) -> list[tuple[SpecData, Latest]]:
+def get_latest_versions(specs: list[SpecData],
+                        token: Optional[str]) -> list[tuple[SpecData, Latest]]:
     """Given a list of specs, return a list of SpecData with latest version.
     Removes any SpecData that does not have a cooresponding version."""
-    with requests.Session() as s:
-        return [(spec, latest) for spec in specs
-                if (latest := rest.get_latest_version(spec, s)) is not None]
+    if token:
+        logging.info(
+            "GITHUB_TOKEN environment variable or --github-token flag is set, "
+            "using GraphQL api")
+        return graphql.latest_versions(specs, token)
+    else:
+        logging.warning(
+            "GITHUB_TOKEN environment variable or --github-token flag is not set, "
+            "using REST api")
+
+        with requests.Session() as s:
+            return [(spec, latest) for spec in specs
+                    if (latest := rest.get_latest_version(spec, s)) is not None
+                    ]

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -23,7 +23,10 @@ def get_latest_versions(specs: list[SpecData], token: Optional[str],
     else:
         logging.warning(
             "GITHUB_TOKEN environment variable or --github-token flag is not set, "
-            "using REST api")
+            "using REST api instead of GraphQL.")
+        logging.warning(
+            "The REST API is slower and you are limited to 60 calls per hour "
+            "without authenticating.")
 
         with requests.Session() as s:
             return [(spec, latest) for spec in specs

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -25,8 +25,8 @@ def get_latest_versions(specs: list[SpecData], token: Optional[str],
             "GITHUB_TOKEN environment variable or --github-token flag is not set, "
             "using REST api instead of GraphQL.")
         logging.warning(
-            "The REST API is slower and you are limited to 60 calls per hour "
-            "without authenticating.")
+            "The REST API requires more connections, gathers more data than is "
+            "needed, and you are limited to 60 requests per hour without a token.")
 
         with requests.Session() as s:
             return [(spec, latest) for spec in specs

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from typing import Optional
 
 import requests
@@ -8,15 +9,17 @@ from .githubapi.latest import Latest
 from .specdata import SpecData
 
 
-def get_latest_versions(specs: list[SpecData],
-                        token: Optional[str]) -> list[tuple[SpecData, Latest]]:
-    """Given a list of specs, return a list of SpecData with latest version.
+def get_latest_versions(specs: list[SpecData], token: Optional[str],
+                        id_cache: Path) -> list[tuple[SpecData, Latest]]:
+    """Given a list of specs, optionally a Github token, and a location to load
+    and store a cache of GraphQL ids, return a list of SpecData with latest version.
     Removes any SpecData that does not have a cooresponding version."""
+
     if token:
         logging.info(
             "GITHUB_TOKEN environment variable or --github-token flag is set, "
             "using GraphQL api")
-        return graphql.latest_versions(specs, token)
+        return graphql.latest_versions(specs, token, id_cache)
     else:
         logging.warning(
             "GITHUB_TOKEN environment variable or --github-token flag is not set, "


### PR DESCRIPTION
Github's GraphQL API allows us to make fewer connections and get only the data we need, but comes with the complexity of caching node IDs and needing Github token authentication.