### PR TITLE
feat: add --rest flag to force usage of REST API

### DIFF
--- a/autocopr/autocopr.py
+++ b/autocopr/autocopr.py
@@ -33,7 +33,7 @@ def main():
     ]
 
     latest_vers = autocopr.latestver.get_latest_versions(
-        specs, args.github_token, root_dir / "graphql_id_cache.json"
+        specs, root_dir / "graphql_id_cache.json", args.github_token, args.rest if args.rest else None
     )
 
     update_summary = [f"{'Name':15}\t{'Old Version':8}\tNew Version"]

--- a/autocopr/cli.py
+++ b/autocopr/cli.py
@@ -42,6 +42,10 @@ def create_parser() -> argparse.ArgumentParser:
         ),
     )
     parser.add_argument(
+        "--rest",
+        help="Forces usage of the Github REST API over the GraphQL API. The GraphQL API is preferred since it typically only needs to make one request.",
+    )
+    parser.add_argument(
         "directory",
         nargs="?",
         help="directory where spec files are located. defaults to the working "

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -11,11 +11,25 @@ from githubapi.latest import Latest
 
 
 def get_latest_versions(
-    specs: list[SpecData], token: Optional[str], id_cache: Path
+    specs: list[SpecData], id_cache: Path, token: Optional[str], rest: Optional[bool]
 ) -> list[tuple[SpecData, Latest]]:
-    """Given a list of specs, optionally a Github token, and a location to load
-    and store a cache of GraphQL ids, return a list of SpecData with latest version.
-    Removes any SpecData that does not have a cooresponding version."""
+    """Given a list of specs, a location to potentially load and store a cache
+    of GraphQL ids, and optionally a Github token and a boolean to force usage
+    of the REST API, return a list of SpecData with latest version. Removes any
+    SpecData that does not have a cooresponding version.
+
+    A GitHub token is required to use the GraphQL API."""
+
+    if rest:
+        logging.info("--rest is set, using REST api")
+
+        if token is None:
+            logging.warning(
+                "The REST API will rate limit you to 60 requests per hour without a Github token. "
+                "You can use the REST API with a token by using the --rest flag and using the "
+                "GITHUB_TOKEN environment variable or --github-token flag.")
+
+        return _rest(specs, token)
 
     if token:
         logging.info(
@@ -23,26 +37,39 @@ def get_latest_versions(
             "using GraphQL api"
         )
 
-        ownerNames = [spec.ownerName for spec in specs]
-        latest = githubapi.graphql.latest_versions(ownerNames, token, id_cache)
+        return _graphql(specs, token, id_cache)
 
+    # This case should only be hit if
+    # 1. --rest was NOT set, so we tried defaulting to GraphQL
+    # 2. --github-token was NOT set, so we do not have a token
+    logging.warning(
+        "GITHUB_TOKEN environment variable or --github-token flag is not set, "
+        "using REST api instead of GraphQL."
+    )
+    logging.warning(
+        "The REST API requires more connections, gathers more data than is "
+        "needed, and you are limited to 60 requests per hour without a token."
+    )
+
+    return _rest(specs)
+
+
+def _graphql(
+    specs: list[SpecData], token: str, id_cache: Path
+) -> list[tuple[SpecData, Latest]]:
+    """Use the graphql API."""
+    ownerNames = [spec.ownerName for spec in specs]
+    latest = githubapi.graphql.latest_versions(ownerNames, token, id_cache)
+
+    return [(spec, latest[key]) for spec in specs if (key := spec.ownerName) in latest]
+
+
+def _rest(specs: list[SpecData], token: Optional[str]) -> list[tuple[SpecData, Latest]]:
+    """Use the REST api."""
+    with requests.Session() as s:
         return [
-            (spec, latest[key]) for spec in specs if (key := spec.ownerName) in latest
+            (spec, latest_ver)
+            for spec in specs
+            if (latest_ver := githubapi.rest.get_latest_version(spec.ownerName, s))
+            is not None
         ]
-    else:
-        logging.warning(
-            "GITHUB_TOKEN environment variable or --github-token flag is not set, "
-            "using REST api instead of GraphQL."
-        )
-        logging.warning(
-            "The REST API requires more connections, gathers more data than is "
-            "needed, and you are limited to 60 requests per hour without a token."
-        )
-
-        with requests.Session() as s:
-            return [
-                (spec, latest_ver)
-                for spec in specs
-                if (latest_ver := githubapi.rest.get_latest_version(spec.ownerName, s))
-                is not None
-            ]

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -67,6 +67,13 @@ def _graphql(
 def _rest(specs: list[SpecData], token: Optional[str]) -> list[tuple[SpecData, Latest]]:
     """Use the REST api."""
     with requests.Session() as s:
+        if token:
+            s.headers.update(
+                {
+                    "Authorization": f"Bearer {token}"
+                }
+            )
+
         return [
             (spec, latest_ver)
             for spec in specs


### PR DESCRIPTION
It also supports tokens, so you can use the REST API authorized. Inspired by conversation in #7, since I find it a bit easier to add new features in a REST API than diving into GraphQL.

~~Also reformats everything with latest ruff.~~