### PR TITLE
fix: fail the script if there's any errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ TL;DR: Automatic version bumper for projects that use Github Releases :)
 - [License](#license)
 
 ## Background
+
 [Fedora](https://fedoraproject.org/) is a Linux distribution that uses
 the [`dnf`](https://docs.fedoraproject.org/en-US/quick-docs/dnf/) package
 manager to install, update, and remove packages/software.
@@ -51,6 +52,13 @@ that is already compiled. However, this requires that you trust the project
 maintainers to provide correct binaries. If you don't, please create your own
 AutoCOPR that builds from source or explore other alternatives below.
 
+I'd also like to point to [RelativeSure's autocopr
+repo](https://github.com/RelativeSure/autocopr) as a downstream repo using
+these scripts in a much more structured manner. You may want to use it as your
+COPR repo since they're packaging much more, or use it as inspiration for
+additional features you could use (such as updating a README.md with version
+numbers).
+
 There are several valid alternatives to a system like this:
 - [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) or
   installing from source with
@@ -59,7 +67,7 @@ There are several valid alternatives to a system like this:
   programs. This is more idiomatic and certainly easier! However, for me I
   really value having one source of updates for my system so I don't need to
   remember all the different sources, so integrating with `dnf` is ideal.
-- There are other COPR repositories that build these. You can go to
+- There are other COPR repositories that build these programs. You can go to
   [Copr](https://doc.rust-lang.org/cargo/commands/cargo-install.html), type in
   a program name, hit the arrow to filter for "package name", and go explore the
   projects and repositories! *Be sure to check a build for its spec file to see
@@ -70,6 +78,7 @@ There are several valid alternatives to a system like this:
   over-engineer a solution for something that is barely a problem.
 
 ## Install/Usage
+
 There's a few different ways to use this repo, so each one will get its own
 section.
 
@@ -96,6 +105,7 @@ sudo dnf copr enable adenl/github-releases
 ```
 
 #### Usage
+
 With the repository installed, you can install like regular from `dnf` - commands
 like `sudo dnf install zellij` or `sudo dnf remove zellij` will work as expected
 and you will receive updates through GNOME Software or `sudo dnf upgrade`.
@@ -105,6 +115,7 @@ See all packages on
 or by looking in the [specs folder](specs).
 
 ### The `autocopr.py` Program
+
 The `autocopr.py` program (in the [`autocopr` folder](autocopr)) checks all
 `.spec` files in the given directory and updates the versions to the latest
 Github Release. This doesn't need to be integrated with CI - this can be run
@@ -187,6 +198,7 @@ for spec files. It also passes a Github token in the environment to allow for
 authentication to the GraphQL library.
 
 ### Integrating with Github Actions and COPR Automatic Builds
+
 This repo has a Github Action at .github/workflows/update.yml that runs the
 script every 24 hours. This process is detailed much further in
 [DOCS.md](DOCS.md), but if you know what you're doing here's a quick summary:

--- a/autocopr/autocopr.py
+++ b/autocopr/autocopr.py
@@ -33,7 +33,10 @@ def main():
     ]
 
     latest_vers = autocopr.latestver.get_latest_versions(
-        specs, root_dir / "graphql_id_cache.json", args.github_token, args.rest if args.rest else None
+        specs,
+        root_dir / "graphql_id_cache.json",
+        args.github_token,
+        args.rest if args.rest else None,
     )
 
     update_summary = [f"{'Name':15}\t{'Old Version':8}\tNew Version"]

--- a/autocopr/autocopr.py
+++ b/autocopr/autocopr.py
@@ -29,8 +29,14 @@ def main():
     specs = [
         parsed
         for spec in root_dir.glob("**/*.spec")
-        if (parsed := autocopr.specdata.parse_spec(spec)) is not None
+        if (parsed := autocopr.specdata.parse_spec(spec))
     ]
+
+    if None in specs:
+        logging.warning("A spec/specs failed to parse, exiting...")
+        exit(1)
+
+    specs = [spec for spec in specs if spec is not None]
 
     latest_vers = autocopr.latestver.get_latest_versions(
         specs,

--- a/autocopr/autocopr.py
+++ b/autocopr/autocopr.py
@@ -26,17 +26,13 @@ def main():
         logging.error("Cannot use --push when not running in a git repository")
         exit(1)
 
-    specs = [
-        parsed
-        for spec in root_dir.glob("**/*.spec")
-        if (parsed := autocopr.specdata.parse_spec(spec))
-    ]
+    non_filtered_specs = [autocopr.specdata.parse_spec(spec) for spec in root_dir.glob("**/*.spec")]
 
-    if None in specs:
+    if None in non_filtered_specs:
         logging.warning("A spec/specs failed to parse, exiting...")
         exit(1)
 
-    specs = [spec for spec in specs if spec is not None]
+    specs = [spec for spec in non_filtered_specs if spec is not None]
 
     latest_vers = autocopr.latestver.get_latest_versions(
         specs,

--- a/autocopr/cli.py
+++ b/autocopr/cli.py
@@ -44,6 +44,7 @@ def create_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--rest",
         help="Forces usage of the Github REST API over the GraphQL API. The GraphQL API is preferred since it typically only needs to make one request.",
+        action="store_true"
     )
     parser.add_argument(
         "directory",

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -58,22 +58,35 @@ def get_latest_versions(
 def _graphql(
     specs: list[SpecData], token: str, id_cache: Path
 ) -> list[tuple[SpecData, Latest]]:
-    """Use the graphql API."""
+    """Use the graphql API. Will exit the program if fetching fails."""
     ownerNames = [spec.ownerName for spec in specs]
     latest = githubapi.graphql.latest_versions(ownerNames, token, id_cache)
 
+    missing_specs = [spec for spec in specs if spec.ownerName not in latest]
+
+    if len(missing_specs) != 0:
+        logging.warning(f"{missing_specs} had errors, exiting...")
+        exit(1)
+    
     return [(spec, latest[key]) for spec in specs if (key := spec.ownerName) in latest]
 
 
 def _rest(specs: list[SpecData], token: Optional[str] = None) -> list[tuple[SpecData, Latest]]:
-    """Use the REST api."""
+    """Use the REST api. Will exit the program if fetching fails."""
     with requests.Session() as s:
         if token:
             s.headers.update({"Authorization": f"Bearer {token}"})
 
-        return [
+        latest = [
             (spec, latest_ver)
             for spec in specs
             if (latest_ver := githubapi.rest.get_latest_version(spec.ownerName, s))
-            is not None
         ]
+
+        missing = [entry[0] for entry in latest if entry[1] is None]
+
+        if len(missing) != 0:
+            logging.warning(f"{missing} had errors, exiting...")
+            exit(1)
+
+        return [entry for entry in latest if entry[1] is not None]

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -65,7 +65,7 @@ def _graphql(
     return [(spec, latest[key]) for spec in specs if (key := spec.ownerName) in latest]
 
 
-def _rest(specs: list[SpecData], token: Optional[str]) -> list[tuple[SpecData, Latest]]:
+def _rest(specs: list[SpecData], token: Optional[str] = None) -> list[tuple[SpecData, Latest]]:
     """Use the REST api."""
     with requests.Session() as s:
         if token:

--- a/autocopr/latestver.py
+++ b/autocopr/latestver.py
@@ -27,7 +27,8 @@ def get_latest_versions(
             logging.warning(
                 "The REST API will rate limit you to 60 requests per hour without a Github token. "
                 "You can use the REST API with a token by using the --rest flag and using the "
-                "GITHUB_TOKEN environment variable or --github-token flag.")
+                "GITHUB_TOKEN environment variable or --github-token flag."
+            )
 
         return _rest(specs, token)
 
@@ -68,11 +69,7 @@ def _rest(specs: list[SpecData], token: Optional[str]) -> list[tuple[SpecData, L
     """Use the REST api."""
     with requests.Session() as s:
         if token:
-            s.headers.update(
-                {
-                    "Authorization": f"Bearer {token}"
-                }
-            )
+            s.headers.update({"Authorization": f"Bearer {token}"})
 
         return [
             (spec, latest_ver)

--- a/autocopr/specdata.py
+++ b/autocopr/specdata.py
@@ -59,5 +59,5 @@ def parse_spec(spec_loc: Path) -> Optional[SpecData]:
                 logging.info(f"Parsed from file: {parsed}")
                 return parsed
 
-    logging.warning(f"Missing name, version or URL in {spec_loc}!")
+    logging.warning(f"Missing name, version or URL field in {spec_loc}!")
     return None

--- a/autocopr/specdata.py
+++ b/autocopr/specdata.py
@@ -59,5 +59,5 @@ def parse_spec(spec_loc: Path) -> Optional[SpecData]:
                 logging.info(f"Parsed from file: {parsed}")
                 return parsed
 
-    logging.warning(f"Missing name, version or URL in {spec_loc}! Skipping")
+    logging.warning(f"Missing name, version or URL in {spec_loc}!")
     return None

--- a/githubapi/rest.py
+++ b/githubapi/rest.py
@@ -30,11 +30,11 @@ def get_latest_version(spec: OwnerName, session: requests.Session) -> Optional[L
         latest_tag: str = req["tag_name"]
         latest_url: str = req["html_url"]
     except KeyError:
-        logging.warning(f"{spec.name} does not have a latest version, skipping")
-        logging.info("Request received:")
+        logging.warning(f"{spec.name} does not have a latest version!")
+        logging.warning("Request received:")
         import json
 
-        logging.info(json.dumps(req, indent=4))
+        logging.warning(json.dumps(req, indent=4))
         return None
 
     # Trims tags like "v0.35.2" to "0.35.2" by cutting from the front until we


### PR DESCRIPTION
Fixes #10. Since this runs unattended, failures should be loud.

Also fits in some minor nits:
- Add RelativeSure's repo to the README as a resource
- run formatter and fix a new lint
- `--rest` wasn't set up as a boolean flag!