### PR TITLE
chore: requests 2.34 has inline types!

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ requires-python = ">= 3.13"
 
 [project.optional-dependencies]
 dev = [
-  "types-requests", # type stubs for requests
   "ruff", # format/linter
   "mypy", # typechecker
   "pip-tools" # Used to create/update requirements.txt


### PR DESCRIPTION
[requests 2.34](https://github.com/psf/requests/releases/tag/v2.34.0) adds inline types, so we can remove `types-requests` from dev dependencies. this doesn't need a new release since it only impacts the dev deps.