### PR TITLE
chore: stricter type-checking and uv dependency cooldown

### DIFF
--- a/.github/workflows/lint-fmt-py.yml
+++ b/.github/workflows/lint-fmt-py.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Lint
         run: uv run --locked ruff check --output-format github
 
+      - name: Enforce full typing coverage
+        run: uv run --locked pyrefly coverage check --output-format github
+
       - name: Typecheck
         run: uv run --locked pyrefly check --output-format github

--- a/autocopr/update.py
+++ b/autocopr/update.py
@@ -10,7 +10,7 @@ from githubapi.latest import Latest
 
 def update_version(
     spec: SpecData, latest: Latest, push: bool = False, verbose: bool = False
-):
+) -> None:
     """Given the location of a spec file, the latest version, and the name of
     the package, update the version in the spec and make a commit with the
     cooresponding COPR tag."""

--- a/githubapi/graphql.py
+++ b/githubapi/graphql.py
@@ -38,12 +38,13 @@ ID = str
 def update_cache(
     id_cache: Path, specs: list[OwnerName], session: requests.Session
 ) -> list[tuple[OwnerName, ID]]:
-    """Given a list of specs, request headers, id cache, and session,
-    load the cache of id keys and fetch any new ones from GraphQl"""
+    """Given a cache location, list of specs, and session,
+    load the cache of id keys and fetch any missing IDs via GraphQL"""
 
     if id_cache.exists():
         with open(id_cache) as cache:
-            ids = json.load(cache)
+            # Maps "owner/name" to the github ID
+            ids: dict[str, ID] = json.load(cache)
 
         logging.info(f"Loaded IDs for {ids.keys()} from {id_cache}")
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dev = [
 
 [tool.uv]
 required-version = "==0.11.25"
+exclude-newer = "3 days"
 
 [tool.pyrefly]
 project-includes = [ "autocopr", "githubapi" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ required-version = "==0.11.25"
 
 [tool.pyrefly]
 project-includes = [ "autocopr", "githubapi" ]
+preset = "strict"
 # https://github.com/facebook/pyrefly/commit/97fd78f013374caae0e8f259c62ca5a6505e876d
 # fixes the issue with requests - once 1.2.0 comes out I should be able to enable this
 # min-severity = "warn"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P3D"
+
 [[package]]
 name = "autocopr"
 version = "1.0.0"


### PR DESCRIPTION
A few additional settings now that I've learned more about uv and pyrefly.

- CI now checks that we have 100% type coverage to ensure new code must be typed
- Using the strict preset pyrefly preset, this is a small project so the strictness is appreciated
- Enforce a 3 day dependency cooldown with uv. I mostly bump via dependabot which is on a 7 day cooldown anyways, but this is a secondary enforcement locally and for devs