### PR TITLE
chore: fix dependabot by only pinning uv in the action, not the project

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,7 @@ runs:
     - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
       with:
         working-directory: ${{ github.action_path }}
+        version: "0.11.25"
 
     - name: Set git user to github-actions[bot]
       shell: bash

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
               packages = with pkgs; [
                 python
                 # When bumping nixpkgs, also bump
-                # - pyproject.toml `tools.uv.required-version` (pinned for deterministic CI)
+                # - action.yml `.runs.steps[0].with.version` (pinned for deterministic CI)
                 uv
 
                 # Shell/github action linters used in CI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "==0.11.25"
+required-version = ">0.11.0"
 exclude-newer = "3 days"
 
 [tool.pyrefly]


### PR DESCRIPTION
dependabot [gave a warning](https://github.com/aidandenlinger/autocopr/network/updates/1499821884) when I had uv pinned to a specific version in `pyproject.toml`:

> [!CAUTION]
> Dependabot does not support your uv version
>
>Dependabot detected the following uv requirement for your project: '==0.11.25'.
>
>Currently, the following uv versions are supported in Dependabot: 0.11.8.
>[Troubleshoot Dependabot errors](https://docs.github.com/github/managing-security-vulnerabilities/troubleshooting-dependabot-errors)

To allow dependabot to work while still keeping a deterministic uv version within this action (to prevent unexpected behavior from a version bump), pyproject.toml is now a min-required version, while action.yml uses a fixed version string.